### PR TITLE
Implement HRRN Queues

### DIFF
--- a/GenerateFiles.py
+++ b/GenerateFiles.py
@@ -59,7 +59,6 @@ if __name__ == "__main__":
                         else:
                             l.append(np.random.randint(1,maxTimeIO))
 
-                    #f.write(",".join(str(x) for x in l) + "\r\n")
                     f.write(",".join(str(x) for x in l) + "\n")
 
     #

--- a/GenerateFiles.py
+++ b/GenerateFiles.py
@@ -59,7 +59,8 @@ if __name__ == "__main__":
                         else:
                             l.append(np.random.randint(1,maxTimeIO))
 
-                    f.write(",".join(str(x) for x in l) + "\r\n")
+                    #f.write(",".join(str(x) for x in l) + "\r\n")
+                    f.write(",".join(str(x) for x in l) + "\n")
 
     #
     # Generate example output file for initial plotting

--- a/simulation.py
+++ b/simulation.py
@@ -276,10 +276,10 @@ def loadProcessesFromCSV(fn):
 # analysis from the simulation since the simulation will likely take a while.
 def writeResultsToCSV(results, fn):
     with open(fn, 'w') as f:
-        f.write("PID,Submitted,Started,Completed,Queues,Executing,IO\r\n")
+        f.write("PID,Submitted,Started,Completed,Queues,Executing,IO\n")
 
         for p in results:
-            f.write(repr(p) + "\r\n")
+            f.write(repr(p) + "\n")
 
 # Load a file, run the simulation, output the results to a file
 def runSimulation(infile, outfile, queues, cpuCount, contextSwitchTime, debug):

--- a/simulation.py
+++ b/simulation.py
@@ -60,11 +60,8 @@ class QueueSPN(Queue):
 class QueueHRRN(Queue):
     def dequeue(self):
         # Find one with the highest: (wait time + service time) / service time
-        serviceTimes = [sum(p.times) for p in self.items] # I think sum(p.times) includes I/O time, this needs to be just the CPU time
-        # might want to try something to only get every other integer in times if we want just the CPU times
-        waitTimes = [p.queues for p in self.items]
+        serviceTimes = [sum(p.times) for p in self.items]
         ratios = [(w+s)/s for w,s in zip(waitTimes,serviceTimes)]
-        #ratios = (waitTimes + serviceTimes) / serviceTimes
         index = np.argmax(ratios)
         item = self.items[index]
 

--- a/simulation.py
+++ b/simulation.py
@@ -61,6 +61,7 @@ class QueueHRRN(Queue):
     def dequeue(self):
         # Find one with the highest: (wait time + service time) / service time
         serviceTimes = [sum(p.times) for p in self.items]
+        waitTimes = [p.queues for p in self.items]
         ratios = [(w+s)/s for w,s in zip(waitTimes,serviceTimes)]
         index = np.argmax(ratios)
         item = self.items[index]


### PR DESCRIPTION
Implemented HRRN queues.

Removed "\r\n" and replaced it with "\n" in file generation logic. On my Windows machine, \r\n was causing a double-spacing effect where blank lines where placed in-between rows of data. This was causing errors, I think because the file reading logic was trying to read the empty files.

@floft Does removing the CR character cause any problems?
